### PR TITLE
Create issues

### DIFF
--- a/issues
+++ b/issues
@@ -1,0 +1,5 @@
+Where is the issue tracker? Unfortunately installation doesn't work for me.
+
+$ ninja -C build/ all install
+ninja: Entering directory `build/'
+ninja: error: loading 'build.ninja': No such file or directory


### PR DESCRIPTION
Installation on Ubuntu 18.04 doesn't work

$ ninja -C build/ all install
ninja: Entering directory `build/'
ninja: error: loading 'build.ninja': No such file or directory
